### PR TITLE
Fix minidumpview.json

### DIFF
--- a/minidumpview.json
+++ b/minidumpview.json
@@ -2,7 +2,7 @@
     "url": "http://www.debuginfo.com/download/minidumpviewfull.zip",
     "version": "1.0.3",
     "bin": [
-        ["mdpview.exe", "MiniDumpView", ""]
+        ["mdpview.exe", "MiniDumpView", ""],
         ["mdpview.exe", "mdpview", ""]
     ]
 }


### PR DESCRIPTION
It was an invalid json file and it was causing error due to missing comma.